### PR TITLE
fix-file-open

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -576,6 +576,15 @@ void TextEditor::showOpenDialog()
         {"C++ Header", "hpp"},
         {"Text File", "txt"},
         {"Lua Script", "lua"}};
+    
+    // Initialize NFD only if needed
+    static bool nfd_initialized = false;
+    if (!nfd_initialized) {
+        if (NFD_Init() == NFD_OKAY) {
+            nfd_initialized = true;
+        }
+    }
+    
     nfdresult_t result = NFD_OpenDialog(&outPath, filters, 4, nullptr); // instead of nullptr here, lets pass the current dir our file explorer is looking at
     if (result == NFD_OKAY)
     {
@@ -597,6 +606,14 @@ void TextEditor::showSaveDialog(const std::string &defaultFileName)
         {"C++ Header", "hpp"},
         {"Text File", "txt"},
         {"Lua Script", "lua"}};
+
+    // Initialize NFD only if needed
+    static bool nfd_initialized = false;
+    if (!nfd_initialized) {
+        if (NFD_Init() == NFD_OKAY) {
+            nfd_initialized = true;
+        }
+    }
 
     nfdresult_t result = NFD_SaveDialog(&savePath, filters, 4, nullptr, defaultFileName.c_str()); // instead of nullptr here, lets pass the current dir our file explorer is looking at
     if (result == NFD_OKAY)


### PR DESCRIPTION
Fixes https://github.com/Grimdonuts/DonutEx/issues/2

The app was crashing when trying to open files because the Native File Dialog library wasn't being initialized properly. The error messages showed GTK issues, but the real problem was that NFD needs to call NFD_Init() before using any file dialogs to set up the display connection correctly.

Added a simple one-time initialization check in the file dialog functions - now it calls NFD_Init() once when first needed instead of jumping straight into dialog creation. Works on both Ubuntu and should be more reliable on Arch too since this is actually the proper way to use the NFD library according to their docs.

The crash was happening because we were trying to create native file dialogs without telling the library to connect to the desktop environment first.